### PR TITLE
ViewModelCommandManager dictionary KeyNotFoundException bugfix

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/ViewModelCommandManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/ViewModelCommandManager.cs
@@ -124,7 +124,7 @@ namespace Catel.MVVM
 
             if (!_instances.ContainsKey(viewModel.UniqueIdentifier))
             {
-                _instances[viewModel.UniqueIdentifier] = new ViewModelCommandManager(viewModel);
+                _instances.Add(viewModel.UniqueIdentifier, new ViewModelCommandManager(viewModel));
             }
 
             return _instances[viewModel.UniqueIdentifier];


### PR DESCRIPTION
If the dictionary does not have the key, it throws KeyNotFoundException. In order to prevent this, Dictionary`s Add method is called now.